### PR TITLE
docs: add AGENTS guidance and refresh README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Guía para contribuciones
+
+- La documentación dentro de este repositorio debe escribirse en español neutro y con un tono profesional.
+- Organiza el contenido en secciones con encabezados Markdown de nivel dos (`##`) y subsecciones más profundas solo si es estrictamente necesario.
+- Los ejemplos de comandos deben ir en bloques de código con la etiqueta del lenguaje correspondiente.
+- Para cambios exclusivamente de documentación no es obligatorio ejecutar pruebas, pero si se ejecuta una verificación de formato debe utilizarse `npm run prettier:verify`.

--- a/README.md
+++ b/README.md
@@ -1,60 +1,66 @@
 # Reload for Salesforce
 
-Reload for Salesforce és una Lightning App empaquetable que centralitza la configuració i l'execució de càrregues de dades amb un enfocament flexible i dinàmic. El framework combina una taula intermèdia universal amb eines de mapping perquè les organitzacions puguin portar dades cap a qualsevol objecte estàndard o personalitzat sense reconfigurar l'esquema cada vegada.
+## Introducción
+Reload for Salesforce es una aplicación Lightning empaquetable que centraliza la configuración y ejecución de cargas de datos con un enfoque flexible y visual. La solución combina una tabla intermedia universal con herramientas de mapeo para que los equipos puedan llevar información a cualquier objeto estándar o personalizado sin reconfigurar el esquema en cada iteración.
 
-## Funcionalitats clau
+## Características principales
+- **Aplicación Lightning dedicada**: la app agrupa pestañas de trabajo y una página de inicio con el componente `Reload Workbench` para guiar a los usuarios durante todo el proceso de carga.
+- **Tabla intermedia universal**: los objetos `Reload Data Batch`, `Reload Staging Record` y `Reload Field Value` almacenan cualquier payload mediante relaciones maestro-detalle y metadatos complementarios (estado, origen, errores, entre otros).
+- **Interfaz interactiva**: el componente LWC muestra lotes recientes, registros en staging y detalle de campos sin que sea necesario editar JSON manualmente.
+- **Permission Set administrado**: el permission set `Reload Admin` garantiza el acceso a la app, a los objetos personalizados y al controlador Apex.
 
-- **Aplicació Lightning dedicada**: l'app "Reload for Salesforce" agrupa pestanyes i una pàgina d'inici amb el component `Reload Workbench` per guiar l'usuari a través de tot el procés.
-- **Taula intermèdia universal**: els objectes `Reload Data Batch`, `Reload Staging Record` i `Reload Field Value` emmagatzemen qualsevol payload mitjançant relacions mestre-detall i informació complementària (estat, origen, errors, etc.).
-- **Interfície interactiva**: el component LWC mostra lots recents, registres estagiats i detalls de camps sense que l'usuari hagi d'editar JSON a mà.
-- **Permission Set administrat**: el permission set `Reload Admin` concedeix l'accés necessari a l'aplicació, als objectes i al controlador Apex.
-
-## Model de dades
-
-| Objecte | Descripció | Camps destacats |
+## Arquitectura de datos
+| Objeto | Descripción | Campos destacados |
 | --- | --- | --- |
-| `Reload_Batch__c` | Agrupa la càrrega en lots i desa el context de l'origen i l'estat global. | Target Object API, Default Operation, Source Type, comptadors i notes |
-| `Reload_Staging__c` | Registre intermig amb payload dinàmic i metadades de processament. | Batch, Status, Record Action, Payload, Error Message |
-| `Reload_Field_Value__c` | Parell camp-valor vinculat a cada registre estagiat per editar-lo fàcilment. | Field API Name, Field Type, Field Value, Is Key |
+| `Reload_Batch__c` | Agrupa la carga en lotes y guarda el contexto del origen junto con el estado global. | Target Object API, Default Operation, Source Type, contadores y notas |
+| `Reload_Staging__c` | Registra los datos intermedios con payload dinámico y metadatos de procesamiento. | Batch, Status, Record Action, Payload, Error Message |
+| `Reload_Field_Value__c` | Relaciona cada registro intermedio con pares campo-valor para su edición. | Field API Name, Field Type, Field Value, Is Key |
 
-## Components i metadades incloses
+## Componentes incluidos
+- Lightning App `Reload for Salesforce` con pestañas de navegación (Lotes, Registros, Valores y Reload Manager).
+- Lightning App Page `Reload Manager` con el componente `Reload Workbench` como panel central.
+- Controlador Apex `ReloadWorkspaceController` acompañado de su clase de pruebas.
+- Permission Set `Reload Admin` con permisos de objeto y campo configurados.
+- Layouts, listas relacionadas y compact layouts adaptados a cada objeto.
 
-- Lightning App `Reload for Salesforce` i pestanyes de navegació (Lots, Registres, Valors, Reload Manager).
-- Lightning App Page `Reload Manager` amb el component `Reload Workbench`.
-- Controlador Apex `ReloadWorkspaceController` i test unitari corresponent.
-- Permission Set `Reload Admin` amb permisos d'objecte i de camp.
-- Layouts, llistes i compact layouts personalitzats per a cada objecte.
+## Requisitos previos
+- CLI de Salesforce (SFDX) instalada y autenticada en la organización de destino.
+- Perfil con permisos para desplegar metadatos y asignar permission sets.
+- Node.js 18+ si se desea ejecutar pruebas unitarias o linting de componentes LWC.
 
-## Desplegament
-
-1. Autentica't a l'org destinació (per exemple, un sandbox):
-
+## Puesta en marcha rápida
+1. Autentica la organización de destino (por ejemplo, un sandbox):
    ```bash
    sfdx auth:web:login --setalias reload-dev --instanceurl https://test.salesforce.com
    ```
-
-2. Desplega el codi al teu entorn:
-
+2. Despliega el código y la configuración de la app:
    ```bash
    sfdx deploy source --sourcepath force-app --target-org reload-dev
    ```
-
-3. Assigna el permission set a l'usuari que hagi de gestionar càrregues:
-
+3. Asigna el permission set al usuario que operará Reload:
    ```bash
-   sfdx force:user:permset:assign --permsetname Reload_Admin --targetusername <usuari>
+   sfdx force:user:permset:assign --permsetname Reload_Admin --targetusername <usuario>
    ```
+4. Accede a la aplicación Lightning "Reload for Salesforce" para revisar lotes recientes, registros en staging y métricas del proceso.
 
-4. Accedeix a l'aplicació Lightning "Reload for Salesforce" i comença a preparar lots de dades.
-
-## Tests
-
-Executa el test unitari inclòs per validar el controlador i obtenir cobertura:
-
+## Ejecución de pruebas
+Ejecuta el test unitario incluido para validar el controlador y asegurar cobertura antes de desplegar a producción:
 ```bash
 sfdx force:apex:test:run --tests ReloadWorkspaceControllerTest --wait 10 --resultformat human --targetusername reload-dev
 ```
 
----
+## Personalización y operación
+- Define tus fuentes de datos y reglas de transformación creando lotes (`Reload_Batch__c`) y registros de staging (`Reload_Staging__c`).
+- Usa los pares campo-valor (`Reload_Field_Value__c`) para validar y ajustar la información antes de confirmar la inserción o actualización en Salesforce.
+- Monitorea el progreso desde la app page `Reload Manager`, que expone métricas clave y atajos para resolver errores.
 
-Aquest repositori segueix l'estructura estàndard de Salesforce DX i es pot empaquetar com a (Managed) Package o distribuir-se mitjançant Change Sets segons convingui.
+## Estructura del repositorio
+- `force-app/` contiene los metadatos de la aplicación, incluyendo objetos personalizados, componentes LWC y clases Apex.
+- `config/` y `manifest/` incluyen archivos auxiliares para despliegue con SFDX.
+- `sfdx-project.json` define los paquetes y paths utilizados por Salesforce DX.
+- Archivos de configuración como `package.json`, `eslint.config.js` y `prettier` scripts permiten aplicar buenas prácticas en el código fuente.
+
+## Recursos y soporte
+- Documentación oficial de Salesforce DX: <https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_intro.htm>
+- Tutoriales Lightning Web Components: <https://developer.salesforce.com/docs/component-library/documentation/en/lwc>
+- Para soporte interno, documenta procesos y decisiones en este repositorio para mantener una trazabilidad clara del framework.


### PR DESCRIPTION
## Summary
- añade el archivo `AGENTS.md` con pautas para documentar en español dentro del repositorio
- reescribe `README.md` en español con secciones de características, arquitectura, despliegue y recursos adicionales

## Testing
- `npm run prettier:verify` *(falló por advertencias de formato previas en archivos ajenos a la documentación y se interrumpió tras detectarlas)*

------
https://chatgpt.com/codex/tasks/task_e_68c89c19cfe083299737971229f5ed24