### PR TITLE
Prevent accidental form submission on Enter

### DIFF
--- a/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
+++ b/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
@@ -36,6 +36,7 @@
           <lightning-record-edit-form
             object-api-name="Reload_Batch__c"
             onsuccess={handleBatchCreated}
+            onsubmit={handleBatchSubmit}
           >
             <lightning-messages></lightning-messages>
             <div class="slds-grid slds-wrap slds-gutters">
@@ -74,7 +75,8 @@
               <lightning-button
                 variant="brand"
                 label="Crear lot"
-                type="submit"
+                type="button"
+                onclick={handleCreateBatchClick}
               ></lightning-button>
             </div>
           </lightning-record-edit-form>

--- a/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.js
+++ b/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.js
@@ -31,6 +31,7 @@ export default class ReloadWorkbench extends LightningElement {
 
   selectedBatchId;
   selectedStagingId;
+  formSubmitRequested = false;
 
   batchColumns = [
     { label: "Batch", fieldName: "Name", type: "text" },
@@ -187,6 +188,25 @@ export default class ReloadWorkbench extends LightningElement {
     if (this.wiredBatchesResult) {
       refreshApex(this.wiredBatchesResult);
     }
+  }
+
+  handleCreateBatchClick() {
+    this.formSubmitRequested = true;
+    const form = this.template.querySelector("lightning-record-edit-form");
+    if (form) {
+      form.submit();
+    } else {
+      this.formSubmitRequested = false;
+    }
+  }
+
+  handleBatchSubmit(event) {
+    if (!this.formSubmitRequested) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    this.formSubmitRequested = false;
   }
 
   resetSelections() {


### PR DESCRIPTION
## Summary
- prevent Enter keypresses from submitting the new batch form unintentionally
- gate lightning-record-edit-form submission behind the explicit "Crear lot" button click

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c89f279d908329890764fea65fc74a