### PR TITLE
Add CSV upload support to Reload Workbench

### DIFF
--- a/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
+++ b/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
@@ -161,6 +161,24 @@
 
     <template if:true={selectedBatch}>
       <lightning-layout-item size="12">
+        <lightning-card title="Pujar registres" icon-name="utility:upload">
+          <div class="slds-var-p-around_small">
+            <p class="slds-text-color_weak slds-var-m-bottom_small">
+              Puja un fitxer CSV relacionat amb el lot seleccionat. El component
+              <code>lightning-file-upload</code> permet fitxers de fins a 2 GB
+              per fitxer.
+            </p>
+            <lightning-file-upload
+              accept={acceptedFormats}
+              label="Selecciona CSV"
+              name="csvUploader"
+              record-id={selectedBatchId}
+              onuploadfinished={handleUploadFinished}
+            ></lightning-file-upload>
+          </div>
+        </lightning-card>
+      </lightning-layout-item>
+      <lightning-layout-item size="12">
         <lightning-card
           title="Registres en memòria intermèdia"
           icon-name="utility:stage"

--- a/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.js
+++ b/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.js
@@ -32,6 +32,8 @@ export default class ReloadWorkbench extends LightningElement {
   selectedBatchId;
   selectedStagingId;
 
+  acceptedFormats = [".csv"];
+
   batchColumns = [
     { label: "Batch", fieldName: "Name", type: "text" },
     { label: "Target Object", fieldName: "Target_Object_API__c", type: "text" },
@@ -257,6 +259,26 @@ export default class ReloadWorkbench extends LightningElement {
       .finally(() => {
         this.fieldValuesLoading = false;
       });
+  }
+
+  handleUploadFinished(event) {
+    const uploadedFiles = event.detail?.files ?? [];
+    const fileNames = uploadedFiles.map((file) => file.name).join(", ");
+    const defaultMessage =
+      uploadedFiles.length > 1
+        ? `S'han pujat ${uploadedFiles.length} fitxers.`
+        : "S'ha pujat el fitxer correctament.";
+    const message = fileNames
+      ? `${defaultMessage} (${fileNames})`
+      : defaultMessage;
+
+    this.dispatchEvent(
+      new ShowToastEvent({
+        title: "Fitxer carregat",
+        message,
+        variant: "success"
+      })
+    );
   }
 
   handleTouchBatch() {


### PR DESCRIPTION
## Summary
- expose a new "Pujar registres" card when a batch is selected
- wire a lightning-file-upload component restricted to CSV files and tied to the batch record
- provide Catalan helper text about the 2 GB file limit and toast feedback when an upload completes

## Testing
- npm run prettier
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8a0e0a2888329aaf8db8d5663b8ff