### PR TITLE
Eliminar el título del formulario de nuevo lote

### DIFF
--- a/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
+++ b/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
@@ -26,7 +26,7 @@
     </lightning-layout-item>
 
     <lightning-layout-item size="12">
-      <lightning-card title="Nou lot de càrrega" icon-name="utility:add">
+      <lightning-card>
         <div class="slds-var-p-around_small">
           <p class="slds-text-color_weak slds-var-m-bottom_small">
             Defineix el lot i després incorpora registres a la taula intermèdia


### PR DESCRIPTION
## Resumen
- se elimina el encabezado del `lightning-card` que mostraba "+ Nou lot de càrrega"

## Pruebas
- no se ejecutaron (no requeridas)


------
https://chatgpt.com/codex/tasks/task_e_68c8b202fcb0832993a40f12031e9af1