### PR TITLE
Fix lookup option highlight state

### DIFF
--- a/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
+++ b/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
@@ -151,7 +151,7 @@
                             aria-labelledby={targetLookupAriaLabelledby}
                           >
                             <template
-                              for:each={targetLookupOptions}
+                              for:each={targetLookupOptionsWithState}
                               for:item="option"
                               for:index="index"
                             >


### PR DESCRIPTION
## Summary
- render the Target Object lookup options using the derived state so the active option reflects keyboard and mouse navigation

## Testing
- npm run lint
- npm run --silent prettier:verify

------
https://chatgpt.com/codex/tasks/task_e_68c8b04cd0ec8329af8ab0734a334fe1