### PR TITLE
Add refresh icon to recent batches button

### DIFF
--- a/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
+++ b/force-app/main/default/lwc/reloadWorkbench/reloadWorkbench.html
@@ -314,6 +314,8 @@
             >
               <lightning-button
                 label="Actualitzar"
+                icon-name="utility:refresh"
+                icon-position="left"
                 onclick={handleRefreshBatches}
               ></lightning-button>
             </div>


### PR DESCRIPTION
## Summary
- add the Salesforce refresh utility icon to the "Actualitzar" button on the recent batches card so the action is clearer

## Testing
- npm run prettier:verify

------
https://chatgpt.com/codex/tasks/task_e_68c8b5401a9c8329a0b7bf6bb44efdb9